### PR TITLE
Use zorkian/datadog-go-api unmarshaller for Precision

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:27a0ba2be705618c3a7015ad9641635c1c4a552175576149d57bb9cf71cb0513"
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  pruneopts = ""
+  revision = "62661b46c4093e2c1f38d943e663db1a29873e80"
+  version = "v2.1.0"
+
+[[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -48,12 +56,20 @@
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
+[[projects]]
+  digest = "1:7edfda530f7530c93ca586729c4ab8fef99fe07f8f136ad0a2b920efbedaf40a"
+  name = "github.com/zorkian/go-datadog-api"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1df5bda80d16ccfa8e99c543dbeb731665acbfca"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/rodaine/hclencoder",
     "github.com/stretchr/testify/assert",
+    "github.com/zorkian/go-datadog-api",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,3 +29,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.1.4"
+
+[[constraint]]
+  name = "github.com/zorkian/go-datadog-api"
+  revision = "1df5bda80d16ccfa8e99c543dbeb731665acbfca"

--- a/convert/decoder_test.go
+++ b/convert/decoder_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,4 +18,35 @@ func TestDecodeFromAPI(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, len(dash.Graphs) > 0)
 	assert.True(t, len(dash.Templates) > 0)
+}
+
+func TestGraphDefinitionDecoder(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *GraphDefinition
+	}{
+		{
+			input:    `{"precision":"1"}`,
+			expected: &GraphDefinition{Precision: "1"},
+		},
+		{
+			input:    `{"precision":1}`,
+			expected: &GraphDefinition{Precision: "1"},
+		},
+		{
+			input:    `{"precision":"100%"}`,
+			expected: &GraphDefinition{Precision: "100%"},
+		},
+		{
+			input:    `{"precision":"*"}`,
+			expected: &GraphDefinition{Precision: "*"},
+		},
+	}
+
+	for _, test := range tests {
+		gd := &GraphDefinition{}
+		err := json.Unmarshal([]byte(test.input), gd)
+		assert.NoError(t, err)
+		assert.EqualValues(t, test.expected, gd)
+	}
 }

--- a/convert/types.go
+++ b/convert/types.go
@@ -1,6 +1,10 @@
 package convert
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/zorkian/go-datadog-api"
+)
 
 type Dashboard struct {
 	Dash `json:"dash" hcl:"resource"`
@@ -26,11 +30,11 @@ type Graph struct {
 }
 
 type GraphDefinition struct {
-	Viz       string    `json:"viz" hcl:"viz"`
-	AutoScale bool      `json:"autoscale,omitempty" hcl:"autoscale" hcle:"omitempty"`
-	Precision string    `json:"precision,omitempty" hcl:"precision" hcle:"omitempty"`
-	Requests  []Request `json:"requests" hcl:"request"`
-	Events    []Event   `json:"events" hcl:"events" hcle:"omitempty"`
+	Viz       string             `json:"viz" hcl:"viz"`
+	AutoScale bool               `json:"autoscale,omitempty" hcl:"autoscale" hcle:"omitempty"`
+	Precision datadog.PrecisionT `json:"precision,omitempty" hcl:"precision" hcle:"omitempty"`
+	Requests  []Request          `json:"requests" hcl:"request"`
+	Events    []Event            `json:"events" hcl:"events" hcle:"omitempty"`
 }
 
 type GraphStyle struct {

--- a/fixtures/input.json
+++ b/fixtures/input.json
@@ -48,7 +48,7 @@
       },
       {
         "definition": {
-          "precision": "1",
+          "precision": 1,
           "viz": "query_value",
           "requests": [
             {


### PR DESCRIPTION
Fixes #3 

See: https://github.com/zorkian/go-datadog-api/pull/194

DataDog API seems to return various types for the "Precision" value in the ScreenBoard type. This fixes that issue by using the defacto Go package for DD Client communication.

It is strange that the unmarshaller will pass values such as "foo" and "bar" though. So this is more of a temporary fix.
