### PR TITLE
Fix Yaxis unmarshalling

### DIFF
--- a/convert/decoder_test.go
+++ b/convert/decoder_test.go
@@ -50,3 +50,46 @@ func TestGraphDefinitionDecoder(t *testing.T) {
 		assert.EqualValues(t, test.expected, gd)
 	}
 }
+
+func float64Pointer(v float64) *float64 {
+	return &v
+}
+
+func stringPointer(v string) *string {
+	return &v
+}
+
+func TestYaxisDecoder(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *Yaxis
+	}{
+		{
+			input:    `{"min":"auto", "max":"auto"}`,
+			expected: &Yaxis{},
+		},
+		{
+			input:    `{"min":"0"}`,
+			expected: &Yaxis{Min: float64Pointer(0)},
+		},
+		{
+			input:    `{"min":"1"}`,
+			expected: &Yaxis{Min: float64Pointer(1)},
+		},
+		{
+			input:    `{"max":"100"}`,
+			expected: &Yaxis{Max: float64Pointer(100)},
+		},
+		{
+			input:    `{"max":"100","scale":"log"}`,
+			expected: &Yaxis{Max: float64Pointer(100), Scale: stringPointer("log")},
+		},
+	}
+
+	for _, test := range tests {
+		y := &Yaxis{}
+		err := json.Unmarshal([]byte(test.input), y)
+		assert.NoError(t, err)
+		assert.EqualValues(t, test.expected, y)
+	}
+}


### PR DESCRIPTION
It's beginning to look like a re-implementation of https://github.com/zorkian/go-datadog-api with the adding of the HCL encoder tags.

It would be better to just use https://github.com/zorkian/go-datadog-api as is and convert the public structs to our structs with our included tags.