### PR TITLE
Allow string based dashboard IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+datadog-fetch-hcl

--- a/client/datadog.go
+++ b/client/datadog.go
@@ -24,9 +24,9 @@ func NewDataDog(apiKey, appKey string) *DataDogClient {
 	}
 }
 
-func (d *DataDogClient) FetchJSON(id int) ([]byte, error) {
+func (d *DataDogClient) FetchJSON(id string) ([]byte, error) {
 	url := fmt.Sprintf(
-		"%s/%d?api_key=%s&application_key=%s",
+		"%s/%s?api_key=%s&application_key=%s",
 		ddDashboardAPIUrl,
 		id,
 		d.apiKey,

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 	dd := client.NewDataDog(apiKey, appKey)
 
-	id := flag.Int("id", 0, "Dashboard ID to retrieve")
+	id := flag.String("id", "0", "Dashboard ID to retrieve")
 	title := flag.String("title", "", "Dashboard Title for TF definition")
 	debug := flag.Bool("debug", false, "Debug Datadog API Output to stderr")
 	flag.Parse()

--- a/script/test
+++ b/script/test
@@ -15,7 +15,7 @@ if [ "$FMT_ERRS" -gt "0" ]; then
 fi
 echo "ok gofmt"
 
-VET_ERRS=$(go tool vet -shadow -all $pkgs 2>&1 | tee /dev/tty | wc -l)
+VET_ERRS=$(go vet -all $pkgs 2>&1 | tee /dev/tty | wc -l)
 if [ "$VET_ERRS" -gt "0" ]; then
   echo "$VET_ERRS Vet error(s) found above."
   exit 1


### PR DESCRIPTION
Given Datadog has moved towards hex-based dashboard IDs, we need to modify the fetching interface to process all IDs as strings.